### PR TITLE
Fix select border variable

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -66,7 +66,7 @@
 
 select.form-control {
   &:not([size]):not([multiple]) {
-    $select-border-width: ($border-width * 2);
+    $select-border-width: ($input-btn-border-width * 2);
     height: calc(#{$input-height} + #{$select-border-width});
   }
 


### PR DESCRIPTION
To get `select`s matching the size of text inputs, a calculation is done which includes the width of the border. However, it uses `$border-width` instead of `$input-btn-border-width`, which means if the two don't match, your `select`s.